### PR TITLE
Fix typos and remove invalid 1.9 entry for ArmorPlus

### DIFF
--- a/ArmorPlus.json
+++ b/ArmorPlus.json
@@ -1,13 +1,8 @@
 {
   "homepage": "http://adf.ly/1YfdD4",
     "promos": {
-    "1.9-latest" :       "2.0.0",
-    "1.9-recommended" :   "2.0.0",
     "1.9.4-latest"     : "2.0.1",
     "1.9.4-recommended" : "2.0.1"
-  },
-  "1.9" : {
-    "2.0.0" : "Ported to 1.9.4"
   },
   "1.9.4" : {
     "2.0.0" : "Ported to 1.9.4 And some Major Changes",

--- a/ArmorPlus.json
+++ b/ArmorPlus.json
@@ -2,9 +2,9 @@
   "homepage": "http://adf.ly/1YfdD4",
     "promos": {
     "1.9-latest" :       "2.0.0",
-    "1.9-recomended" :   "2.0.0",
+    "1.9-recommended" :   "2.0.0",
     "1.9.4-latest"     : "2.0.1",
-    "1.9.4-recomended" : "2.0.1"
+    "1.9.4-recommended" : "2.0.1"
   },
   "1.9" : {
     "2.0.0" : "Ported to 1.9.4"

--- a/MoreDimensions.json
+++ b/MoreDimensions.json
@@ -1,9 +1,9 @@
 {
     "promos": {
     "1.8-latest"     : "1.5.1",
-    "1.8-recomended" : "1.5.1",
+    "1.8-recommended" : "1.5.1",
     "1.9-latest"     : "1.6b",
-    "1.9-recomended" : "1.6b"
+    "1.9-recommended" : "1.6b"
   },
   "1.8" : {
     "1.5.1" : "Added a version checker"

--- a/UsefulRecipes.json
+++ b/UsefulRecipes.json
@@ -1,9 +1,9 @@
 {
     "promos": {
     "1.8.9-latest"     : "1.1.0",
-    "1.8.9-recomended" : "1.1.0",
+    "1.8.9-recommended": "1.1.0",
     "1.9-latest"     : "1.2",
-    "1.9-recomended" : "1.2",
+    "1.9-recommended" : "1.2",
   },
   "1.8.9" : {
     "1.1.0" : "First release of the mod",

--- a/WeaponsPlus.json
+++ b/WeaponsPlus.json
@@ -2,7 +2,7 @@
   "homepage": "http://adf.ly/12020783/weaponsplus-page",
     "promos": {
     "1.9.4-latest"     : "1.5.0",
-    "1.9.4-recomended" : "1.5.0"
+    "1.9.4-recommended" : "1.5.0"
   },
   "1.9.4" : {
     "1.0.0-ALPHA" : "Created",


### PR DESCRIPTION
- Fixes the typos on "recommended", which made the file not follow specifications and cause NotEnoughMods/NotEnoughModPolling#182
- The MC 1.9 version of ArmorPlus isn't 2.0.0 as 2.0.0 requires MC 1.9.4. I assume that entry was made as a mistake.
